### PR TITLE
Exclude Crunchyroll's iframe in MAL

### DIFF
--- a/src/code/01_header.js
+++ b/src/code/01_header.js
@@ -26,7 +26,7 @@
 // @include     /^https?:\/\/(w+.?\.)?9anime\.ch\/watch\//
 //
 // @include     /^https?:\/\/(www\.)?crunchyroll.com\//
-// @exclude     /^https?:\/\/(www\.)?crunchyroll.com\/($|acct|anime|comics|edit|email|forum|home|inbox|library|login|manga|newprivate|news|notifications|order|outbox|pm|search|store|user|videos)/
+// @exclude     /^https?:\/\/(www\.)?crunchyroll.com\/($|acct|anime|comics|edit|email|forum|home|inbox|library|login|manga|newprivate|news|notifications|order|outbox|pm|search|store|user|videos|affiliate_iframeplayer)/
 //
 // @include     /^https?:\/\/(w+.?\.)?gogoanime\.tv\/([^/]+$|category\/)/
 // @include     /^https?:\/\/(w+.?\.)?gogoanime\.io\/([^/]+$|category\/)/

--- a/src/kissanimelist.user.js
+++ b/src/kissanimelist.user.js
@@ -26,7 +26,7 @@
 // @include     /^https?:\/\/(w+.?\.)?9anime\.ch\/watch\//
 //
 // @include     /^https?:\/\/(www\.)?crunchyroll.com\//
-// @exclude     /^https?:\/\/(www\.)?crunchyroll.com\/($|acct|anime|comics|edit|email|forum|home|inbox|library|login|manga|newprivate|news|notifications|order|outbox|pm|search|store|user|videos)/
+// @exclude     /^https?:\/\/(www\.)?crunchyroll.com\/($|acct|anime|comics|edit|email|forum|home|inbox|library|login|manga|newprivate|news|notifications|order|outbox|pm|search|store|user|videos|affiliate_iframeplayer)/
 //
 // @include     /^https?:\/\/(w+.?\.)?gogoanime\.tv\/([^/]+$|category\/)/
 // @include     /^https?:\/\/(w+.?\.)?gogoanime\.io\/([^/]+$|category\/)/


### PR DESCRIPTION
A little pull request to avoid having the floating menu button inside Crunchyroll's iframe in MAL when there's no video available.

![image](https://user-images.githubusercontent.com/11521400/44689044-17e73700-aa4e-11e8-97dd-3ec8359f3eb5.png)

or when flash isn't enabled:

![image](https://user-images.githubusercontent.com/11521400/44689564-d9527c00-aa4f-11e8-8ad3-7d5711cc9133.png)


since the button don't do much there anyway

![image](https://user-images.githubusercontent.com/11521400/44689100-436a2180-aa4e-11e8-8ca5-c5c7ccaf1278.png)
